### PR TITLE
fix: remove local recordings folder and fix video speed issue

### DIFF
--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -33,7 +33,9 @@ MIN_DETECTIONS_TO_SAVE = int(os.getenv("MIN_DETECTIONS_TO_SAVE", "1"))
 # ==========================
 # Recording Settings
 # ==========================
-RECORDINGS_DIR = os.getenv("RECORDINGS_DIR", os.path.join(os.path.dirname(__file__), "recordings"))
+# Use system temp directory instead of local recordings folder
+import tempfile
+RECORDINGS_DIR = tempfile.gettempdir()
 RECORDING_CODEC = os.getenv("RECORDING_CODEC", "mp4v")  # or 'avc1' for H.264
 RECORDING_FPS = int(os.getenv("RECORDING_FPS", "30"))
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -43,8 +43,7 @@ async def lifespan(app: FastAPI):
     load_custom_model()
     logger.info(f"Device: {get_device_info()}")
 
-    # Initialize recordings directory
-    initialize_recordings_dir()
+    # Recordings directory initialization removed - using system temp directory
 
     # Initialize HTTP client for database operations
     if SAVE_DETECTIONS_ENABLED:

--- a/src/backend/video/recording.py
+++ b/src/backend/video/recording.py
@@ -25,8 +25,11 @@ active_recordings: Dict[str, dict] = {}
 
 
 def initialize_recordings_dir():
-    os.makedirs(RECORDINGS_DIR, exist_ok=True)
-    logger.info(f"Recordings directory: {RECORDINGS_DIR}")
+    """
+    Deprecated: Recordings directory initialization removed.
+    Using system temp directory instead to avoid local storage.
+    """
+    logger.info(f"Recordings will be stored in system temp directory: {RECORDINGS_DIR}")
 
 
 def create_video_writer(recording_id: str) -> Optional[cv2.VideoWriter]:


### PR DESCRIPTION
This commit addresses two issues with the video recording feature:

1. Remove local recordings folder - Videos are now stored in system temp directory instead of a dedicated local recordings folder to avoid cluttering local storage.

2. Fix video recording speed - Implemented proper frame timing control to ensure videos are recorded at the correct speed (30 FPS). Previously, frames were written as fast as they arrived, causing videos to be sped up or slowed down depending on stream rate.

Changes:
- config.py: Changed RECORDINGS_DIR to use tempfile.gettempdir()
- main.py: Removed initialize_recordings_dir() call
- recording.py: Deprecated initialize_recordings_dir() function
- detection_track.py: Added frame timing control (last_frame_time, target_frame_interval) to write frames at consistent 30 FPS intervals