### PR TITLE
fix: use WebM format and dynamic FPS for proper video recording speed

### DIFF
--- a/src/backend/api/routes.py
+++ b/src/backend/api/routes.py
@@ -148,10 +148,13 @@ def setup_routes(app: FastAPI):
         if not os.path.exists(filepath):
             raise HTTPException(status_code=404, detail="Video not found")
 
+        # Detect media type based on file extension
+        media_type = "video/webm" if filename.endswith(".webm") else "video/mp4"
+
         # Return video file with proper content type
         return FileResponse(
             filepath,
-            media_type="video/mp4",
+            media_type=media_type,
             filename=filename
         )
 
@@ -169,10 +172,13 @@ def setup_routes(app: FastAPI):
         if not os.path.exists(filepath):
             raise HTTPException(status_code=404, detail="Video not found")
 
+        # Detect media type based on file extension
+        media_type = "video/webm" if filename.endswith(".webm") else "video/mp4"
+
         # Force download with proper headers
         return FileResponse(
             filepath,
-            media_type="video/mp4",
+            media_type=media_type,
             filename=filename,
             headers={"Content-Disposition": f"attachment; filename={filename}"}
         )

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -36,8 +36,8 @@ MIN_DETECTIONS_TO_SAVE = int(os.getenv("MIN_DETECTIONS_TO_SAVE", "1"))
 # Use system temp directory instead of local recordings folder
 import tempfile
 RECORDINGS_DIR = tempfile.gettempdir()
-RECORDING_CODEC = os.getenv("RECORDING_CODEC", "mp4v")  # or 'avc1' for H.264
-RECORDING_FPS = int(os.getenv("RECORDING_FPS", "30"))
+# Note: Video format is WebM (VP8/VP9) for browser compatibility
+# FPS is dynamically set based on actual stream FPS to avoid speed issues
 
 # ==========================
 # Model Settings

--- a/src/backend/video/detection_track.py
+++ b/src/backend/video/detection_track.py
@@ -56,8 +56,6 @@ class RtspDetectionTrack(VideoStreamTrack):
         # Recording support
         self.recording = False
         self.video_writer: Optional[cv2.VideoWriter] = None
-        self.recording_frame_count = 0  # Count frames for recording
-        self.recording_target_fps = 30.0  # Target recording FPS
 
     async def recv(self) -> VideoFrame:
         """Receive and process a video frame"""
@@ -124,21 +122,10 @@ class RtspDetectionTrack(VideoStreamTrack):
         cv2.putText(img, f"Device: {device}", (10, 110),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255, 0, 255), 2)
 
-        # Write to video file if recording with proper frame rate control
+        # Write every frame to video if recording (no frame skipping)
+        # VideoWriter FPS is set based on actual stream FPS when recording starts
         if self.recording and self.video_writer is not None:
-            # Calculate which frames to write based on actual FPS vs target recording FPS
-            # If stream is 60 FPS and target is 30 FPS, write every other frame
-            # If stream is 90 FPS and target is 30 FPS, write every 3rd frame
-
-            actual_fps = current_fps if current_fps > 0 else 30.0
-            frame_skip_ratio = actual_fps / self.recording_target_fps
-
-            # Write frame if it should be included based on the ratio
-            # Example: if ratio is 2.0, write when frame_count % 2 == 0
-            if frame_skip_ratio <= 1.0 or (self.recording_frame_count % int(frame_skip_ratio)) == 0:
-                self.video_writer.write(img)
-
-            self.recording_frame_count += 1
+            self.video_writer.write(img)
 
         img = img.astype(np.uint8)
         out = VideoFrame.from_ndarray(img, format="bgr24")
@@ -150,8 +137,7 @@ class RtspDetectionTrack(VideoStreamTrack):
         """Start recording frames to video file"""
         self.recording = True
         self.video_writer = video_writer
-        self.recording_frame_count = 0  # Reset frame counter
-        logger.info(f"Started recording video frames at {self.recording_target_fps} FPS")
+        logger.info(f"Started recording video frames at actual stream FPS")
 
     def stop_recording(self):
         """Stop recording frames"""
@@ -159,7 +145,6 @@ class RtspDetectionTrack(VideoStreamTrack):
         if self.video_writer is not None:
             self.video_writer.release()
             self.video_writer = None
-        self.recording_frame_count = 0  # Reset frame counter
         logger.info("Stopped recording video frames")
 
 


### PR DESCRIPTION
This commit fixes the root cause of video speed issues and playback problems:

Problem Analysis:
- Stream FPS: ~10 FPS (YOLO inference rate)
- Previous recording: hardcoded 30 FPS
- Result: 10 frames/sec encoded as 30 FPS = video plays 3x faster

Solutions Implemented:

1. Dynamic FPS Based on Actual Stream Rate
   - Get actual stream FPS when recording starts (get_fps())
   - Set VideoWriter FPS to match actual stream (not hardcoded)
   - Write every frame without skipping (natural recording)
   - Default to 10 FPS if FPS not yet calculated

2. WebM Format for Browser Compatibility
   - Changed from MP4 (H.264/mp4v) to WebM (VP8/VP9)
   - WebM is natively supported by all modern browsers
   - Better browser playback without transcoding
   - Try VP80 codec first, fallback to VP90

3. API Routes Update
   - Auto-detect media type based on file extension
   - Support both .webm and .mp4 files
   - Proper MIME types for streaming and download

Changes:
- recording.py: Use WebM format, dynamic FPS detection
- detection_track.py: Remove frame skipping logic, write all frames
- routes.py: Auto-detect video MIME type (.webm/.mp4)
- config.py: Update documentation for new approach

Result: Videos now record at correct real-time speed and play directly in browser without format/MIME type errors.