### PR TITLE
fix: record video at full 10 FPS instead of decimated 5 FPS

### DIFF
--- a/src/backend/video/detection_track.py
+++ b/src/backend/video/detection_track.py
@@ -61,7 +61,6 @@ class RtspDetectionTrack(VideoStreamTrack):
         self.frame_queue: Optional[queue.Queue] = None
         self.writer_thread: Optional[threading.Thread] = None
         self.stop_writer_thread = False
-        self.recording_frame_counter = 0  # Counter for frame decimation
 
     async def recv(self) -> VideoFrame:
         """Receive and process a video frame"""
@@ -129,20 +128,14 @@ class RtspDetectionTrack(VideoStreamTrack):
                     cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255, 0, 255), 2)
 
         # Add frame to queue for background video writing (non-blocking)
-        # Use frame decimation: only copy and queue every other frame
-        # This reduces expensive img.copy() overhead by 50% while maintaining stream FPS
+        # Background thread handles encoding to prevent blocking main pipeline
         if self.recording and self.frame_queue is not None:
-            self.recording_frame_counter += 1
-
-            # Record every 2nd frame (decimation factor = 2)
-            # Stream: 10 FPS, Video: 5 FPS (but video speed is still normal)
-            if self.recording_frame_counter % 2 == 0:
-                try:
-                    # Copy and queue frame (non-blocking)
-                    # img.copy() is expensive (~2-5ms for 1280x720x3 image)
-                    self.frame_queue.put_nowait(img.copy())
-                except queue.Full:
-                    pass  # Skip frame if queue is full to maintain performance
+            try:
+                # Use put_nowait to avoid blocking
+                # img.copy() is necessary for thread safety
+                self.frame_queue.put_nowait(img.copy())
+            except queue.Full:
+                pass  # Skip frame if queue is full to maintain stream FPS
 
         img = img.astype(np.uint8)
         out = VideoFrame.from_ndarray(img, format="bgr24")
@@ -176,7 +169,6 @@ class RtspDetectionTrack(VideoStreamTrack):
         self.recording = True
         self.video_writer = video_writer
         self.stop_writer_thread = False
-        self.recording_frame_counter = 0  # Reset counter
 
         # Create queue for frames (max 30 frames buffered)
         self.frame_queue = queue.Queue(maxsize=30)
@@ -185,7 +177,7 @@ class RtspDetectionTrack(VideoStreamTrack):
         self.writer_thread = threading.Thread(target=self._video_writer_thread, daemon=True)
         self.writer_thread.start()
 
-        logger.info(f"Started recording with background thread and frame decimation (non-blocking)")
+        logger.info(f"Started recording with background thread at full FPS (non-blocking)")
 
     def stop_recording(self):
         """Stop recording frames and cleanup background thread"""

--- a/src/backend/video/recording.py
+++ b/src/backend/video/recording.py
@@ -82,16 +82,12 @@ async def start_recording(client_id: str, detection_track) -> Optional[str]:
         filename = f"recording_{recording_id}.webm"
         filepath = os.path.join(RECORDINGS_DIR, filename)
 
-        # Get actual stream FPS and divide by 2 for frame decimation
-        # We only record every 2nd frame to reduce copy overhead
+        # Get actual stream FPS for recording
         actual_fps = get_fps()
         if actual_fps <= 0:
             actual_fps = 10.0  # Default to 10 FPS if not yet calculated
 
-        # Use half FPS for recording (frame decimation factor = 2)
-        recording_fps = actual_fps / 2.0
-
-        logger.info(f"Recording at {recording_fps:.1f} FPS (stream: {actual_fps:.1f} FPS, decimation: 2x)")
+        logger.info(f"Recording at {actual_fps:.1f} FPS (full stream rate)")
 
         # Create video writer with WebM format (VP8 codec) for browser compatibility
         # WebM is natively supported by all modern browsers
@@ -105,11 +101,11 @@ async def start_recording(client_id: str, detection_track) -> Optional[str]:
             writer = cv2.VideoWriter(
                 filepath,
                 fourcc,
-                recording_fps,  # Use decimated FPS (half of stream FPS)
+                actual_fps,  # Use actual stream FPS (10 FPS)
                 (RESIZE_WIDTH, RESIZE_HEIGHT)
             )
             if writer.isOpened():
-                logger.info(f"Using codec: {fourcc} at {recording_fps:.1f} FPS")
+                logger.info(f"Using codec: {fourcc} at {actual_fps:.1f} FPS")
                 break
             writer.release()
             writer = None


### PR DESCRIPTION
Remove frame decimation to record all frames at full stream rate.

Changes:
- detection_track.py: Remove decimation logic and frame counter
- recording.py: Use actual_fps instead of actual_fps/2
- Video now records at 10 FPS (same as stream)

Note: Background thread still used for non-blocking encoding. User may experience slight FPS impact due to img.copy() overhead, but video quality is improved with full 10 FPS.