### PR TITLE
fix: prevent double-release of VideoWriter and improve stop sequence

### DIFF
--- a/src/backend/api/routes.py
+++ b/src/backend/api/routes.py
@@ -109,13 +109,14 @@ def setup_routes(app: FastAPI):
         if not is_recording(client_id):
             return {"success": False, "error": "Not recording"}
 
+        # Stop recording on detection track FIRST (releases writer)
+        detection_track = get_detection_track(client_id)
+        if detection_track:
+            detection_track.stop_recording()
+
+        # Then save metadata to database
         recording_data = await stop_recording(client_id)
         if recording_data:
-            # Stop recording on detection track
-            detection_track = get_detection_track(client_id)
-            if detection_track:
-                detection_track.stop_recording()
-
             return {
                 "success": True,
                 "recording": recording_data,

--- a/src/backend/video/recording.py
+++ b/src/backend/video/recording.py
@@ -151,10 +151,9 @@ async def stop_recording(client_id: str) -> Optional[dict]:
         recording_info = active_recordings.pop(client_id)
         recording_id = recording_info["recording_id"]
         filepath = recording_info["filepath"]
-        writer = recording_info["writer"]
 
-        # Stop writing
-        writer.release()
+        # Note: Writer is released by detection_track.stop_recording()
+        # Don't release here to avoid double-release
 
         # Get file info (use Jakarta timezone)
         file_size = os.path.getsize(filepath)


### PR DESCRIPTION
This fixes the "Failed to stop recording" error by:

1. Fix Double Release Issue
   - Remove writer.release() from recording.py (line 157)
   - Keep only one release in detection_track.stop_recording()
   - VideoWriter.release() was being called twice causing error

2. Fix Stop Sequence
   - Call detection_track.stop_recording() FIRST
   - Then call recording.stop_recording() for metadata
   - Proper order prevents access to already-released writer

3. Improve Thread Cleanup
   - Increase join timeout: 5s → 10s for queue drain
   - Add try/except around writer.release() for safety
   - Log thread status and release success
   - Warn if thread doesn't finish in time

Changes:
- routes.py: Swap order of detection_track and recording stop
- detection_track.py: Better error handling and logging
- recording.py: Remove duplicate writer.release()

Result: Recording stops cleanly without errors.