### PR TITLE
fix: correct prisma import statements to use named export

### DIFF
--- a/src/app/api/auv-status/latest/route.ts
+++ b/src/app/api/auv-status/latest/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 // GET /api/auv-status/latest - Get the most recent AUV status
 export async function GET() {

--- a/src/app/api/auv-status/route.ts
+++ b/src/app/api/auv-status/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 // POST /api/auv-status - Save AUV status data
 export async function POST(request: NextRequest) {

--- a/src/app/api/telemetry/fetch/route.ts
+++ b/src/app/api/telemetry/fetch/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 const RASPI_TELEMETRY_URL = 'http://192.168.2.2:14552/telemetry';
 

--- a/src/app/api/telemetry/latest/route.ts
+++ b/src/app/api/telemetry/latest/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 // GET /api/telemetry/latest - Get the most recent telemetry data
 export async function GET() {

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import prisma from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 // POST /api/telemetry - Save telemetry data from Raspberry Pi
 export async function POST(request: NextRequest) {


### PR DESCRIPTION
Changed all prisma imports from default export to named export to match the actual export in @/lib/prisma.ts

Files updated:
- src/app/api/telemetry/fetch/route.ts
- src/app/api/telemetry/route.ts
- src/app/api/telemetry/latest/route.ts
- src/app/api/auv-status/route.ts
- src/app/api/auv-status/latest/route.ts

Before: import prisma from '@/lib/prisma'
After: import { prisma } from '@/lib/prisma'