### PR TITLE
feat: change AUV status tracking to MediaMTX player accessibility

### DIFF
--- a/src/app/api/mediamtx/health/route.ts
+++ b/src/app/api/mediamtx/health/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const MEDIAMTX_PLAYER_URL = 'http://192.168.2.2:8889/cam/';
+
+/**
+ * Calculate connection strength based on response time
+ */
+function calculateConnectionStrength(responseTimeMs: number): string {
+  if (responseTimeMs < 500) {
+    return 'Strong'; // Very fast response
+  } else if (responseTimeMs < 1500) {
+    return 'Moderate'; // Acceptable response
+  } else {
+    return 'Weak'; // Slow response
+  }
+}
+
+/**
+ * Calculate uptime in seconds from first connected time
+ */
+function calculateUptime(firstConnectedTime: Date | null): number {
+  if (!firstConnectedTime) return 0;
+
+  const now = new Date();
+  const diffMs = now.getTime() - firstConnectedTime.getTime();
+  return Math.floor(diffMs / 1000);
+}
+
+/**
+ * GET /api/mediamtx/health
+ * Check if MediaMTX player is accessible and update AUV status
+ */
+export async function GET() {
+  const startTime = Date.now();
+  let isOnline = false;
+  let connectionStrength = 'Disconnected';
+  let responseTime = 0;
+
+  try {
+    // Try to fetch MediaMTX player page with timeout
+    const response = await fetch(MEDIAMTX_PLAYER_URL, {
+      method: 'HEAD', // Use HEAD for faster response
+      signal: AbortSignal.timeout(5000), // 5 second timeout
+    });
+
+    responseTime = Date.now() - startTime;
+    isOnline = response.ok; // true if status 2xx
+
+    if (isOnline) {
+      connectionStrength = calculateConnectionStrength(responseTime);
+    }
+  } catch (error) {
+    // If fetch fails (network error, timeout, etc), treat as offline
+    isOnline = false;
+    connectionStrength = 'Disconnected';
+    responseTime = Date.now() - startTime;
+  }
+
+  try {
+    // Get the latest AUV status to check if we have a first connected time
+    const latestStatus = await prisma.aUVStatus.findFirst({
+      orderBy: { timestamp: 'desc' },
+    });
+
+    let firstConnectedTime: Date | null = null;
+
+    if (isOnline) {
+      // If currently online, use existing firstConnectedTime or set new one
+      if (latestStatus?.isOnline && latestStatus.lastStreamTime) {
+        // Was online before, keep the original first connected time
+        firstConnectedTime = latestStatus.lastStreamTime;
+      } else {
+        // Just came online, set current time as first connected
+        firstConnectedTime = new Date();
+      }
+    } else {
+      // If offline, keep the last known first connected time for history
+      // but uptime will be 0
+      firstConnectedTime = latestStatus?.lastStreamTime || null;
+    }
+
+    const uptime = isOnline ? calculateUptime(firstConnectedTime) : 0;
+
+    // Save current status to database
+    await prisma.aUVStatus.create({
+      data: {
+        isOnline,
+        connectionStrength,
+        uptimeSeconds: uptime,
+        locationStatus: 'Active',
+        lastStreamTime: firstConnectedTime,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        isOnline,
+        connectionStrength,
+        uptimeSeconds: uptime,
+        responseTimeMs: responseTime,
+        mediaPlayerUrl: MEDIAMTX_PLAYER_URL,
+        timestamp: new Date().toISOString(),
+      },
+    });
+  } catch (dbError) {
+    console.error('Database error while updating AUV status:', dbError);
+
+    // Still return the health check result even if DB save fails
+    return NextResponse.json({
+      success: true,
+      data: {
+        isOnline,
+        connectionStrength,
+        responseTimeMs: responseTime,
+        mediaPlayerUrl: MEDIAMTX_PLAYER_URL,
+        timestamp: new Date().toISOString(),
+      },
+      warning: 'Failed to save to database',
+    });
+  }
+}

--- a/src/components/StreamComponent.tsx
+++ b/src/components/StreamComponent.tsx
@@ -1,11 +1,6 @@
 'use client';
 
 import { useEffect, useRef, useState, useCallback } from 'react';
-import {
-  updateStreamConnected,
-  updateStreamDisconnected,
-  updateStreamPerformance,
-} from '@/lib/auv-status';
 
 interface StreamComponentProps {
   /** contoh: ws://localhost:8000 */
@@ -49,7 +44,6 @@ export default function StreamComponent({
   const [modelInfo, setModelInfo] = useState<ModelInfo | null>(null);
   const [performanceData, setPerformanceData] = useState<PerformanceData | null>(null);
   const [logs, setLogs] = useState<string[]>([]);
-  const [streamStartTime, setStreamStartTime] = useState<Date | null>(null);
 
   // Recording state
   const [isRecording, setIsRecording] = useState(false);
@@ -119,25 +113,6 @@ export default function StreamComponent({
       if (perfIntervalRef.current) clearInterval(perfIntervalRef.current);
     };
   }, [apiUrl, isStreaming, isClient]);
-
-  // --- AUV Status updates based on performance ---
-  useEffect(() => {
-    if (!isClient || !isStreaming || !streamStartTime) return;
-
-    // Update AUV status every 5 seconds with current performance metrics
-    const updateStatus = async () => {
-      const fps = performanceData?.fps || 0;
-      await updateStreamPerformance(streamStartTime, fps, targetFps);
-    };
-
-    // Initial update
-    updateStatus();
-
-    // Then update every 5 seconds
-    const interval = setInterval(updateStatus, 5000);
-
-    return () => clearInterval(interval);
-  }, [isClient, isStreaming, streamStartTime, performanceData, targetFps]);
 
   // --- WebRTC bootstrap ---
   const initializeWebRTC = async () => {
@@ -313,16 +288,8 @@ export default function StreamComponent({
     try {
       if (source === 'server') await startServerStream();
       else await startDeviceStream();
-
-      const startTime = new Date();
       setIsStreaming(true);
-      setStreamStartTime(startTime);
       addLog('Stream started');
-
-      // Update AUV status to online
-      updateStreamConnected(startTime).catch(err => {
-        console.error('Failed to update AUV status on stream start:', err);
-      });
     } catch (e: any) {
       addLog(`Start failed: ${e?.message || String(e)}`);
     }
@@ -365,13 +332,7 @@ export default function StreamComponent({
       setIsStreaming(false);
       setConnectionStatus('disconnected');
       setPerformanceData(null);
-      setStreamStartTime(null);
       addLog('Stopped');
-
-      // Update AUV status to offline
-      updateStreamDisconnected().catch(err => {
-        console.error('Failed to update AUV status on stream stop:', err);
-      });
     } catch {
       addLog('Stop error');
     }

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -91,6 +91,26 @@ export default function DashboardContent({
     return () => clearInterval(interval);
   }, []);
 
+  // Background polling: Check MediaMTX player health every 5 seconds
+  // This updates AUV status based on whether http://192.168.2.2:8889/cam/ is accessible
+  useEffect(() => {
+    const pollMediaMTX = async () => {
+      try {
+        await fetch('/api/mediamtx/health');
+      } catch (error) {
+        console.error('Failed to poll MediaMTX health:', error);
+      }
+    };
+
+    // Poll immediately on mount
+    pollMediaMTX();
+
+    // Then poll every 5 seconds
+    const interval = setInterval(pollMediaMTX, 5000);
+
+    return () => clearInterval(interval);
+  }, []);
+
   const telemetry = telemetryData?.data;
   const auvStatus = auvData?.data;
 


### PR DESCRIPTION
Changed AUV status tracking from RTSP stream connection to MediaMTX player page accessibility (http://192.168.2.2:8889/cam/). Uptime now persists across page refreshes by storing first connected time in database.

Changes:
- Created /api/mediamtx/health endpoint to check MediaMTX player accessibility
  * Uses HTTP HEAD request to http://192.168.2.2:8889/cam/
  * Returns isOnline=true if page is accessible (status 2xx)
  * Calculates connection strength based on response time:
    - Strong: < 500ms
    - Moderate: 500-1500ms
    - Weak: > 1500ms
    - Disconnected: Not accessible

- Persistent uptime tracking:
  * Stores firstConnectedTime (lastStreamTime) when MediaMTX first becomes accessible
  * Keeps this time even when temporarily disconnected
  * Calculates uptime from firstConnectedTime when online
  * Uptime persists across page refreshes

- Updated DashboardContent:
  * Added background polling to /api/mediamtx/health every 5 seconds
  * Dashboard displays real-time status from database
  * SWR auto-refreshes data every 3 seconds

- Removed StreamComponent AUV status updates:
  * Removed streamStartTime state
  * Removed updateStreamConnected/Disconnected/Performance calls
  * Removed AUV status update useEffect
  * AUV status now independent of stream start/stop

Flow:
1. Dashboard polls /api/mediamtx/health every 5s
2. Endpoint checks if http://192.168.2.2:8889/cam/ is accessible
3. Updates AUV status in database with current state
4. Dashboard SWR fetches latest status from database
5. Uptime calculated from persistent firstConnectedTime

Benefits:
- AUV status reflects actual MediaMTX player availability
- Uptime doesn't reset on page refresh
- Independent of WebRTC stream connection
- Accurate connection strength based on response time