### PR TITLE
feat: update telemetry structure and implement dual-condition AUV status

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,16 +99,21 @@ model Recording {
 // Model untuk menyimpan data telemetry dari AUV
 model Telemetry {
   id               String   @id @default(cuid())
+  // Attitude data
+  rollDeg          Float    @map("roll_deg") // Roll dalam derajat
+  pitchDeg         Float    @map("pitch_deg") // Pitch dalam derajat
+  yawDeg           Float    @map("yaw_deg") // Yaw dalam derajat
   // Compass data
-  yawDeg           Float    @map("yaw_deg") // Heading dalam derajat
+  headingDeg       Float    @map("heading_deg") // Heading dalam derajat
   // Battery data
   voltageV         Float    @map("voltage_v") // Voltage dalam Volt
-  currentA         Float    @map("current_a") // Current dalam Ampere
+  currentA         Float?   @map("current_a") // Current dalam Ampere (nullable)
   remainingPercent Float    @map("remaining_percent") // Battery remaining dalam persen
+  consumedMah      Float?   @map("consumed_mah") // Battery consumed dalam mAh (nullable)
   // Health status
-  gyroOk           Boolean  @map("gyro_ok") // Status gyroscope
-  accelOk          Boolean  @map("accel_ok") // Status accelerometer
-  magOk            Boolean  @map("mag_ok") // Status magnetometer
+  gyroCal          Boolean  @map("gyro_cal") // Status gyroscope calibration
+  accelCal         Boolean  @map("accel_cal") // Status accelerometer calibration
+  magCal           Boolean  @map("mag_cal") // Status magnetometer calibration
   // Metadata
   timestamp        DateTime @default(now()) // Waktu data diterima
   createdAt        DateTime @default(now()) @map("created_at")

--- a/src/app/api/health/check/route.ts
+++ b/src/app/api/health/check/route.ts
@@ -1,0 +1,215 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const MEDIAMTX_PLAYER_URL = 'http://192.168.2.2:8889/cam/';
+const RASPI_TELEMETRY_URL = 'http://192.168.2.2:14552/telemetry';
+
+/**
+ * Calculate connection strength based on response time
+ */
+function calculateConnectionStrength(responseTimeMs: number): string {
+  if (responseTimeMs < 500) {
+    return 'Strong';
+  } else if (responseTimeMs < 1500) {
+    return 'Moderate';
+  } else {
+    return 'Weak';
+  }
+}
+
+/**
+ * Calculate uptime in seconds from first connected time
+ */
+function calculateUptime(firstConnectedTime: Date | null): number {
+  if (!firstConnectedTime) return 0;
+
+  const now = new Date();
+  const diffMs = now.getTime() - firstConnectedTime.getTime();
+  return Math.floor(diffMs / 1000);
+}
+
+/**
+ * Check if telemetry data has changed from previous reading
+ * Compares attitude and compass values
+ */
+function isTelemetryDataChanging(
+  current: any,
+  previous: any
+): boolean {
+  if (!previous) return true; // First time, consider as changing
+
+  // Compare critical values (attitude and compass)
+  const attitudeChanged =
+    current.attitude.roll_deg !== previous.rollDeg ||
+    current.attitude.pitch_deg !== previous.pitchDeg ||
+    current.attitude.yaw_deg !== previous.yawDeg;
+
+  const compassChanged =
+    current.compass.heading_deg !== previous.headingDeg;
+
+  return attitudeChanged || compassChanged;
+}
+
+/**
+ * GET /api/health/check
+ * Comprehensive health check:
+ * 1. Check MediaMTX player accessibility
+ * 2. Fetch and check if telemetry data is changing
+ * 3. Update AUV status based on both conditions
+ */
+export async function GET() {
+  let isMediaMTXAccessible = false;
+  let isTelemetryChanging = false;
+  let mediaResponseTime = 0;
+  let telemetryData: any = null;
+
+  try {
+    // 1. Check MediaMTX player accessibility
+    const mediaStartTime = Date.now();
+    try {
+      const mediaResponse = await fetch(MEDIAMTX_PLAYER_URL, {
+        method: 'HEAD',
+        signal: AbortSignal.timeout(5000),
+      });
+      mediaResponseTime = Date.now() - mediaStartTime;
+      isMediaMTXAccessible = mediaResponse.ok;
+    } catch (error) {
+      isMediaMTXAccessible = false;
+      mediaResponseTime = Date.now() - mediaStartTime;
+    }
+
+    // 2. Fetch current telemetry data
+    try {
+      const telemetryResponse = await fetch(RASPI_TELEMETRY_URL, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (telemetryResponse.ok) {
+        telemetryData = await telemetryResponse.json();
+
+        // Validate required fields
+        if (
+          telemetryData?.attitude &&
+          telemetryData?.compass &&
+          telemetryData?.battery &&
+          telemetryData?.health
+        ) {
+          // Get previous telemetry to compare
+          const previousTelemetry = await prisma.telemetry.findFirst({
+            orderBy: { timestamp: 'desc' },
+          });
+
+          // Check if data is changing
+          isTelemetryChanging = isTelemetryDataChanging(
+            telemetryData,
+            previousTelemetry
+          );
+
+          // Save new telemetry to database
+          await prisma.telemetry.create({
+            data: {
+              rollDeg: telemetryData.attitude.roll_deg,
+              pitchDeg: telemetryData.attitude.pitch_deg,
+              yawDeg: telemetryData.attitude.yaw_deg,
+              headingDeg: telemetryData.compass.heading_deg,
+              voltageV: telemetryData.battery.voltage_v,
+              currentA: telemetryData.battery.current_a,
+              remainingPercent: telemetryData.battery.remaining_percent,
+              consumedMah: telemetryData.battery.consumed_mAh,
+              gyroCal: telemetryData.health.gyro_cal,
+              accelCal: telemetryData.health.accel_cal,
+              magCal: telemetryData.health.mag_cal,
+            },
+          });
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching telemetry:', error);
+      isTelemetryChanging = false;
+    }
+
+    // 3. Determine overall online status
+    // AUV is online ONLY if BOTH conditions are met:
+    // - MediaMTX player is accessible
+    // - Telemetry data is changing
+    const isOnline = isMediaMTXAccessible && isTelemetryChanging;
+
+    // 4. Calculate connection strength (based on MediaMTX response time)
+    const connectionStrength = isOnline
+      ? calculateConnectionStrength(mediaResponseTime)
+      : 'Disconnected';
+
+    // 5. Update AUV status
+    try {
+      const latestStatus = await prisma.aUVStatus.findFirst({
+        orderBy: { timestamp: 'desc' },
+      });
+
+      let firstConnectedTime: Date | null = null;
+
+      if (isOnline) {
+        // If currently online, use existing firstConnectedTime or set new one
+        if (latestStatus?.isOnline && latestStatus.lastStreamTime) {
+          firstConnectedTime = latestStatus.lastStreamTime;
+        } else {
+          firstConnectedTime = new Date();
+        }
+      } else {
+        // If offline, keep the last known first connected time
+        firstConnectedTime = latestStatus?.lastStreamTime || null;
+      }
+
+      const uptime = isOnline ? calculateUptime(firstConnectedTime) : 0;
+
+      // Save current status to database
+      await prisma.aUVStatus.create({
+        data: {
+          isOnline,
+          connectionStrength,
+          uptimeSeconds: uptime,
+          locationStatus: 'Active',
+          lastStreamTime: firstConnectedTime,
+        },
+      });
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          isOnline,
+          connectionStrength,
+          uptimeSeconds: uptime,
+          mediaPlayerAccessible: isMediaMTXAccessible,
+          telemetryDataChanging: isTelemetryChanging,
+          mediaResponseTimeMs: mediaResponseTime,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch (dbError) {
+      console.error('Database error while updating AUV status:', dbError);
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          isOnline,
+          connectionStrength,
+          mediaPlayerAccessible: isMediaMTXAccessible,
+          telemetryDataChanging: isTelemetryChanging,
+          mediaResponseTimeMs: mediaResponseTime,
+          timestamp: new Date().toISOString(),
+        },
+        warning: 'Failed to save to database',
+      });
+    }
+  } catch (error) {
+    console.error('Error in health check:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Health check failed',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/telemetry/fetch/route.ts
+++ b/src/app/api/telemetry/fetch/route.ts
@@ -25,20 +25,28 @@ export async function GET() {
     const data = await response.json();
 
     // Validate required fields
-    if (!data.compass || !data.battery || !data.health) {
+    if (!data.attitude || !data.compass || !data.battery || !data.health) {
       throw new Error('Invalid telemetry data from Raspberry Pi');
     }
 
     // Save to database
     const telemetry = await prisma.telemetry.create({
       data: {
-        yawDeg: data.compass.yaw_deg,
+        // Attitude
+        rollDeg: data.attitude.roll_deg,
+        pitchDeg: data.attitude.pitch_deg,
+        yawDeg: data.attitude.yaw_deg,
+        // Compass
+        headingDeg: data.compass.heading_deg,
+        // Battery
         voltageV: data.battery.voltage_v,
         currentA: data.battery.current_a,
         remainingPercent: data.battery.remaining_percent,
-        gyroOk: data.health.gyro_ok,
-        accelOk: data.health.accel_ok,
-        magOk: data.health.mag_ok,
+        consumedMah: data.battery.consumed_mAh,
+        // Health
+        gyroCal: data.health.gyro_cal,
+        accelCal: data.health.accel_cal,
+        magCal: data.health.mag_cal,
       },
     });
 


### PR DESCRIPTION
Updated telemetry data structure to match new endpoint response format and implemented dual-condition AUV status tracking based on both MediaMTX accessibility and telemetry data changes.

Telemetry Schema Changes:
- Updated Telemetry model to match new response structure:
  * Added attitude fields: rollDeg, pitchDeg, yawDeg
  * Changed compass from yawDeg to headingDeg
  * Updated battery: made currentA and consumedMah nullable
  * Updated health: changed *Ok fields to *Cal (calibration status)
- Generated new Prisma client with updated schema

API Changes:
- Updated /api/telemetry/fetch to handle new data structure:
  * Parse attitude, compass, battery, health from new format
  * Save all fields including nullable ones correctly
- Created /api/health/check endpoint for comprehensive health monitoring:
  * Checks MediaMTX player accessibility (http://192.168.2.2:8889/cam/)
  * Fetches and compares telemetry data to detect changes
  * AUV is online ONLY if BOTH conditions are met:
    - MediaMTX player is accessible (response 2xx)
    - Telemetry data is changing (attitude/compass values differ)
  * Calculates connection strength based on MediaMTX response time
  * Maintains persistent uptime across page refreshes
  * Saves telemetry and AUV status to database

Dashboard Changes:
- Replaced separate polling endpoints with unified /api/health/check
- Updated telemetry display to show new data structure:
  * Added Attitude card showing roll, pitch, yaw
  * Updated Compass card to show headingDeg
  * Updated Battery to handle nullable currentA
  * Updated Health to show calibration status (CAL/UNCAL)
- Changed grid layout from 3 columns to 4 for new data
- Fixed heading display in location details section

Data Change Detection Logic:
- Compares current telemetry with previous database entry
- Detects changes in attitude (roll, pitch, yaw) and compass (heading)
- If no previous data exists, considers data as changing (first run)
- Only marks as changing if actual values differ

Response Format:
Old structure had: compass.yaw_deg, health.gyro_ok New structure has:
  - attitude: {roll_deg, pitch_deg, yaw_deg}
  - compass: {heading_deg}
  - battery: {voltage_v, current_a, remaining_percent, consumed_mAh}
  - health: {gyro_cal, accel_cal, mag_cal}

Benefits:
- More accurate AUV status (requires both MediaMTX AND data changing)
- Prevents false-positive online status when data is stale
- Richer telemetry data with attitude information
- Persistent uptime tracking across refreshes
- Single unified health check endpoint

This ensures AUV is only marked online when BOTH the stream is accessible AND the telemetry data is actively updating.